### PR TITLE
Fix NPE during dockerfile build

### DIFF
--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -67,6 +67,18 @@
       <artifactId>maven-archiver</artifactId>
       <version>3.0.0</version>
     </dependency>
+    
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-archiver</artifactId>
+      <version>3.1.1</version>
+    </dependency>
+    
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.18</version>
+    </dependency>
 
     <dependency>
       <groupId>org.sonatype.plexus</groupId>


### PR DESCRIPTION
This PR addresses the NPE during `maven dockerfile:build`.

Relevant commits:
https://github.com/codehaus-plexus/plexus-archiver/issues/28
https://github.com/apache/maven-archiver/commit/0b1cf25e61bae420c3c6788634b0b26c0eef98c0#diff-600376dffeb79835ede4a0b285078036